### PR TITLE
Update ungoogled-chromium-portable.json

### DIFF
--- a/bucket/ungoogled-chromium-portable.json
+++ b/bucket/ungoogled-chromium-portable.json
@@ -43,12 +43,12 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/macchrome/winchrome/releases/download/v$version-r$matchBuild-Win64/ungoogled-chromium-$version-$matchID_Win64.7z",
-                "extract_dir": "ungoogled-chromium-$version-1_Win64"
+                "url": "https://github.com/macchrome/winchrome/releases/download/v$version-r$matchBuild-Win64/ungoogled-chromium-$version-$matchId_Win64.7z",
+                "extract_dir": "ungoogled-chromium-$version-$matchId_Win64"
             },
             "32bit": {
-                "url": "https://github.com/macchrome/winchrome/releases/download/v$version-r$matchBuild-Win64/Ungoogled-Chromium-$version-$matchID_Win32.7z",
-                "extract_dir": "Ungoogled-Chromium-$version-1_Win32"
+                "url": "https://github.com/macchrome/winchrome/releases/download/v$version-r$matchBuild-Win64/Ungoogled-Chromium-$version-$matchId_Win32.7z",
+                "extract_dir": "Ungoogled-Chromium-$version-$matchId_Win32"
             }
         },
         "hash": {


### PR DESCRIPTION
fix use of matchId